### PR TITLE
Allow sns and sqs client config

### DIFF
--- a/lib/aws/broker/base.rb
+++ b/lib/aws/broker/base.rb
@@ -22,7 +22,7 @@ module Aws
       end
 
       def sns
-        @sns ||= Aws::SNS::Client.new
+        config.sns
       end
 
       def config

--- a/lib/aws/broker/config.rb
+++ b/lib/aws/broker/config.rb
@@ -2,7 +2,7 @@ module Aws
   class Broker
     class Config
 
-      attr_accessor :enabled, :queue_prefix, :topic_prefix
+      attr_accessor :enabled, :queue_prefix, :topic_prefix, :sqs, :sns
       alias_method :enabled?, :enabled
 
       def initialize
@@ -11,6 +11,13 @@ module Aws
         self.topic_prefix = nil
       end
 
+      def sqs
+        @sqs ||= Aws::SQS::Client.new
+      end
+
+      def sns
+        @sns ||= Aws::SNS::Client.new
+      end
     end
   end
 end

--- a/lib/aws/broker/subscriber.rb
+++ b/lib/aws/broker/subscriber.rb
@@ -74,9 +74,12 @@ module Aws
       end
 
       def sqs
-        @sqs ||= Aws::SQS::Client.new
+        config.sqs
       end
 
+      def config
+        Broker.config
+      end
     end
   end
 end

--- a/spec/aws/broker/config_spec.rb
+++ b/spec/aws/broker/config_spec.rb
@@ -7,6 +7,8 @@ describe Aws::Broker::Config do
   it { should have_attr_accessor(:enabled) }
   it { should have_attr_accessor(:queue_prefix) }
   it { should have_attr_accessor(:topic_prefix) }
+  it { should have_attr_accessor(:sns) }
+  it { should have_attr_accessor(:sqs) }
   it { expect(subject.method(:enabled?)).to eq(subject.method(:enabled)) }
 
 end

--- a/spec/aws/broker/publisher_spec.rb
+++ b/spec/aws/broker/publisher_spec.rb
@@ -9,7 +9,7 @@ describe Aws::Broker::Publisher do
 
   before do
     Aws::Broker.config.topic_prefix = 'tpfx'
-    allow(Aws::SNS::Client).to receive(:new) { sns }
+    Aws::Broker.config.sns = sns
   end
 
   after do

--- a/spec/aws/broker/subscriber_spec.rb
+++ b/spec/aws/broker/subscriber_spec.rb
@@ -11,8 +11,8 @@ describe Aws::Broker::Subscriber do
   before do
     Aws::Broker.config.queue_prefix = 'qpfx'
     Aws::Broker.config.topic_prefix = 'tpfx'
-    allow(Aws::SNS::Client).to receive(:new) { sns }
-    allow(Aws::SQS::Client).to receive(:new) { sqs }
+    Aws::Broker.config.sns = sns
+    Aws::Broker.config.sqs = sqs
   end
   after do
     Aws::Broker.config.queue_prefix = nil


### PR DESCRIPTION
Allows for configuration like
```
Aws::Broker.configure do |config|
  config.sqs = Aws::SQS::Client.new(some_sqs_options)
  config.sns = Aws::SNS::Client.new(some_sns_options)
end
```